### PR TITLE
move more to ref impl section

### DIFF
--- a/ERCS/erc-7841.md
+++ b/ERCS/erc-7841.md
@@ -184,22 +184,13 @@ On the receiving side, EVM chains would type cast `address(parsedAddress)` on th
 
 ### Arbitrary message payload
 
-The `Message.payload` field is designed for maximum flexibility, capable of encoding arbitrary data, including application-specific structures like the `CrossChainOrder` from [ERC-7683](./eip-7683.md) (See *Example Usage* section below for details of this integration). In contrast to some existing bridge designs that restrict the payload to function calls, the message payload in our design can also represent simpler data types, such as a boolean status flag for acknowledgments. This flexibility enables a wider range of use cases and simplifies integration across various applications.
+The `Message.payload` field is designed for maximum flexibility, capable of encoding arbitrary data, including application-specific structures like the `CrossChainOrder` from ERC-7683 (See *Example Usage* section below for details of this integration). In contrast to some existing bridge designs that restrict the payload to function calls, the message payload in our design can also represent simpler data types, such as a boolean status flag for acknowledgments. This flexibility enables a wider range of use cases and simplifies integration across various applications.
 
 ### Use Metadata Digest Instead of `sessionId` for Message Query Key
 
 For message lookups in the mailbox, the query key is derived from the hash of all message metadata rather than relying on a single `sessionId` field. This is because the `sessionId` derivation is customizable and may not adequately bind to key metadata like source and destination addresses. In contrast, the wrapping messaging protocol may enforce permissions for sending or receiving based on these metadata fields, so the query key must bind to the entire set of metadata.
 
 Observe that when applications allow users to define `sessionId`, these values may not be unique across messages. Depending on the implementation of the inbox, this could be a concern. For example,  a mapping-based inbox needs an additional *nullifier set* to enforce the uniqueness of message metadata and avoid message overwrites in the case of a colliding map-key.
-
-### Gas Cost
-
-The most costly operations are `sstore` during `Mailbox.populateInbox()`, which writes to the mapping `inbox` in contract storage, and `sload`, during `Mailbox.recv()` which reads from the `inbox` in storage. Luckily, Mailboxes costs on L2 are much cheaper. In cases of more gas-sensitive chains and applications, we suggest these potential optimizations:
-
-- `delete inbox[key]` during `.recv()` to get gas refunds for cleaning some storage
-  - Synchronous messages are cleaned up at the end of the same block in which they are populated. L2 can optionally implement gas optimizations for such block ephemeral storage.
-- utilize the [EIP-2930](./eip-2930) access list to “pre-warm” predictable storage slots for lower execution cost
-- batch-populate inbox messages and cluster them under fewer keys (bucketed mapping) e.g.: `mapping(bytes32 bucketKey => mapping(bytes32 => bytes)`
 
 ### Pre-filled Inbox
 
@@ -215,9 +206,9 @@ As mentioned above, pre-filling the inbox of the destination chain incurs additi
 
 In comparison to Inter-blockchain Communication(IBC)-like standards, this ERC is designed to work in a *stateless* manner. Messages do not need to pass a proof from the source chain at the time they are consumed on the destination chain. This allows use cases such as synchronous composability and intra-block messaging since messages don’t need to include finalized state from the source chain. Additionally, this ERC does not require multiple steps to establish a link between two chains. Messages can be directly sent from one chain to another in a single step.
 
-[ERC-7683](./eip-7683.md) standardizes intent-based systems by defining structs for orders and interfaces for settlement smart contracts. This standard is application-specific and aimed at designers of cross-chain intent systems, while our proposal is more general and targets developers implementing arbitrary cross-chain applications. However, an intent system based on ERC-7683 **can be built on top** of our standard due to its modularity. An application implementing ERC-7683 could use the `Mailbox` API defined in this proposal to send `originData` from event messages between the source chain (where user funds are deposited) and the destination chain(s) (where intents are solved). We provide more details in the *Example Usage* section.
+ERC-7683 standardizes intent-based systems by defining structs for orders and interfaces for settlement smart contracts. This standard is application-specific and aimed at designers of cross-chain intent systems, while our proposal is more general and targets developers implementing arbitrary cross-chain applications. However, an intent system based on ERC-7683 **can be built on top** of our standard due to its modularity. An application implementing ERC-7683 could use the `Mailbox` API defined in this proposal to send `originData` from event messages between the source chain (where user funds are deposited) and the destination chain(s) (where intents are solved). We provide more details in the *Example Usage* section.
 
-### Reference Implementations
+## Reference Implementations
 
 We show a *possible* implementation of the mailbox contract for synchronous messaging protocol, and explain how it can be easily modified to support asynchronous protocols as well.
 
@@ -365,6 +356,15 @@ To extend the synchronous mailbox to support asynchronous protocols, we only nee
 - At the settlement layer, enforce that the destination chain’s inbox is a **subset** of the source chain’s outbox messages, rather than a full equality check.
   - Consequently, change the accumulator algorithm used to compute `inboxDigest,outboxDigest` to ones with efficient subset proof.
 - Remove the `_reset()` logic since all messages for async will be permanently stored.
+
+### Note on Gas Cost
+
+The most costly operations are `sstore` during `Mailbox.populateInbox()`, which writes to the mapping `inbox` in contract storage, and `sload`, during `Mailbox.recv()` which reads from the `inbox` in storage. Luckily, Mailboxes costs on L2 are much cheaper. In cases of more gas-sensitive chains and applications, we suggest these potential optimizations:
+
+- `delete inbox[key]` during `.recv()` to get gas refunds for cleaning some storage
+  - Synchronous messages are cleaned up at the end of the same block in which they are populated. L2 can optionally implement gas optimizations for such block ephemeral storage.
+- utilize the [EIP-2930](./eip-2930) access list to “pre-warm” predictable storage slots for lower execution cost
+- batch-populate inbox messages and cluster them under fewer keys (bucketed mapping) e.g.: `mapping(bytes32 bucketKey => mapping(bytes32 => bytes)`
 
 
 ### Example Usage - Sync and Async Cross-chain Transfers


### PR DESCRIPTION
addressing: 
- https://github.com/ethereum/ERCs/pull/766#discussion_r2005908004
- https://github.com/ethereum/ERCs/pull/766#discussion_r1895999469 (by turning "Reference Implementation" as h2 header, and all example usage being h3 subsections of it)
- https://github.com/ethereum/ERCs/pull/766#discussion_r1895997899
